### PR TITLE
use URI::db instead of Mojo::URL

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,5 @@
 # You can install this projct with curl -L http://cpanmin.us | perl - https://github.com/jhthorsen/dbix-tempdb/archive/master.tar.gz
+requires "perl"            => "5.010001";
 requires "DBI"             => "1.60";
 requires "URI::db"         => "0.15";
 requires "URI::QueryParam" => "1.69";

--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,6 @@
 # You can install this projct with curl -L http://cpanmin.us | perl - https://github.com/jhthorsen/dbix-tempdb/archive/master.tar.gz
-requires "Mojolicious" => "6.00";
-requires "DBI"         => "1.60";
+requires "DBI"             => "1.60";
+requires "URI::db"         => "0.15";
+requires "URI::QueryParam" => "1.69";
 
 test_requires "Test::More" => "0.88";

--- a/lib/DBIx/TempDB.pm
+++ b/lib/DBIx/TempDB.pm
@@ -74,7 +74,8 @@ use Cwd ();
 use DBI;
 use File::Basename ();
 use File::Spec;
-use Mojo::URL;    # because I can't figure out how to use URI.pm
+use URI::db;
+use URI::QueryParam;
 use Sys::Hostname ();
 
 use constant CWD => eval { File::Basename::dirname(Cwd::abs_path($0)) };
@@ -85,7 +86,7 @@ use constant MAX_OPEN_FDS => eval { use POSIX qw( sysconf _SC_OPEN_MAX ); syscon
 
 our $VERSION = '0.06';
 
-our %SCHEMA_DATABASE = (postgresql => 'postgres', mysql => 'mysql');
+our %SCHEMA_DATABASE = (pg => 'postgres', mysql => 'mysql');
 
 my $START_DB_INDEX = 0;
 
@@ -120,8 +121,8 @@ sub create_database {
     $self->_drop_from_child               if $self->{drop_from_child} == 1;
     $self->_drop_from_double_forked_child if $self->{drop_from_child} == 2;
     $self->{created}++;
-    $self->{url}->path($name);
-    $ENV{DBIX_TEMP_DB_URL} = $self->{url}->to_string;
+    $self->{url}->dbname($name);
+    $ENV{DBIX_TEMP_DB_URL} = $self->{url}->uri->as_string;
     $START_DB_INDEX++;
     return $self;
   }
@@ -139,7 +140,7 @@ L<DBI/connect>.
 
 Note that this method cannot be called as an object method before
 L</create_database> is called. You can on the other hand call it as a class
-method, with an L<Mojo::URL> or URL string as input.
+method, with a L<URI::db> or URL string as input.
 
 =cut
 
@@ -147,12 +148,15 @@ sub dsn {
   my ($self, $url) = @_;
 
   if (!ref $self and $url) {
-    $url = Mojo::URL->new($url) unless ref $url;
-    $self->can(sprintf '_dsn_for_%s', $url->scheme)->($self, $url, $url->path->to_string);
+    $url = URI::db->new($url) unless ref $url and $url->isa('URI::_db');
+    unless ($url->has_recognized_engine) {
+      confess "Scheme @{[$url->engine]} is not recognized as a database engine for connection url $url";
+    }
+    $self->can(sprintf '_dsn_for_%s', $url->canonical_engine)->($self, $url, $url->dbname);
   }
   else {
     confess 'Cannot return DSN before create_database() is called.' unless $self->{database_name};
-    $self->can(sprintf '_dsn_for_%s', $self->url->scheme)->($self, $self->url, $self->{database_name});
+    $self->can(sprintf '_dsn_for_%s', $self->url->canonical_engine)->($self, $self->url, $self->{database_name});
   }
 }
 
@@ -255,16 +259,19 @@ The default is subject to change!
 
 sub new {
   my $class   = shift;
-  my $url     = Mojo::URL->new(shift || '');
+  my $url     = URI::db->new(shift || '');
+  unless ($url->has_recognized_engine) {
+    confess "Scheme @{[$url->engine]} is not recognized as a database engine for connection url $url";
+  }
   my $self    = bless {@_, url => $url}, $class;
-  my $dsn_for = sprintf '_dsn_for_%s', $url->scheme || '';
+  my $dsn_for = sprintf '_dsn_for_%s', $url->canonical_engine || '';
 
   unless ($self->can($dsn_for)) {
-    confess "Cannot generate temp database for '@{[$url->scheme]}'. $class\::$dsn_for() is missing";
+    confess "Cannot generate temp database for '@{[$url->canonical_engine]}'. $class\::$dsn_for() is missing";
   }
 
   $self->{drop_from_child} ||= 0;
-  $self->{schema_database} ||= $SCHEMA_DATABASE{$url->scheme};
+  $self->{schema_database} ||= $SCHEMA_DATABASE{$url->canonical_engine};
   $self->{template}        ||= 'tmp_%U_%X_%H%i';
   warn "[TempDB:$$] schema_database=$self->{schema_database}\n" if DEBUG;
 
@@ -278,8 +285,8 @@ sub new {
 
   $url = $self->url;
 
-Returns the input URL as L<Mojo::URL> compatible object. This URL will have
-the L<path|Mojo::URL/path> part set to the database from L</create_database>,
+Returns the input URL as L<URI::db> compatible object. This URL will have
+the L<dbname|URI::db/dbname> part set to the database from L</create_database>,
 but not I<until> after L</create_database> is actually called.
 
 The URL returned can be passed directly to modules such as L<Mojo::Pg>
@@ -287,7 +294,7 @@ and L<Mojo::mysql>.
 
 =cut
 
-sub url { shift->{url} }
+sub url { shift->{url}->uri }
 
 sub DESTROY {
   my $self = shift;
@@ -301,7 +308,7 @@ sub _cleanup {
   my $self = shift;
 
   eval {
-    if ($self->url->scheme eq 'sqlite') {
+    if ($self->url->canonical_engine eq 'sqlite') {
       unlink $self->{database_name} or die $!;
     }
     else {
@@ -316,7 +323,7 @@ sub _cleanup {
 sub _create_database {
   my ($self, $name) = @_;
 
-  if ($self->url->scheme eq 'sqlite') {
+  if ($self->url->canonical_engine eq 'sqlite') {
     require IO::File;
     use Fcntl qw( O_CREAT O_EXCL O_RDWR );
     IO::File->new->open($name, O_CREAT | O_EXCL | O_RDWR) or die "open $name O_CREAT|O_EXCL|O_RDWR: $!\n";
@@ -326,18 +333,17 @@ sub _create_database {
   }
 }
 
-sub _dsn_for_postgresql {
+sub _dsn_for_pg {
   my ($class, $url, $database_name) = @_;
-  my %opt = %{$url->query->to_hash};
+  my %opt = %{$url->query_form_hash};
   my ($dsn, @userinfo);
 
-  $database_name =~ s!^/+!!;
-  $dsn = "dbi:Pg:dbname=$database_name";
-
-  if (my $host = $url->host) { $dsn .= ";host=$host" }
-  if (my $port = $url->port) { $dsn .= ";port=$port" }
-  if (($url->userinfo // '') =~ /^([^:]+)(?::([^:]+))?$/) { @userinfo = ($1, $2) }
-  if (my $service = delete $opt{service}) { $dsn .= "service=$service" }
+  $url = URI::db->new($url);
+  $url->dbname($database_name);
+  $url->query_param_delete($_) for $url->query_param;
+  if (my $service = delete $opt{service}) { $url->query_param(service => $service) }
+  $dsn = $url->dbi_dsn;
+  @userinfo = ($url->user, $url->password);
 
   $opt{AutoCommit}          //= 1;
   $opt{AutoInactiveDestroy} //= 1;
@@ -349,15 +355,14 @@ sub _dsn_for_postgresql {
 
 sub _dsn_for_mysql {
   my ($class, $url, $database_name) = @_;
-  my %opt = %{$url->query->to_hash};
+  my %opt = %{$url->query_form_hash};
   my ($dsn, @userinfo);
 
-  $database_name =~ s!^/+!!;
-  $dsn = "dbi:mysql:dbname=$database_name";
-
-  if (my $host = $url->host) { $dsn .= ";host=$host" }
-  if (my $port = $url->port) { $dsn .= ";port=$port" }
-  if (($url->userinfo // '') =~ /^([^:]+)(?::([^:]+))?$/) { @userinfo = ($1, $2) }
+  $url = URI::db->new($url);
+  $url->dbname($database_name);
+  $url->query_param_delete($_) for $url->query_param;
+  $dsn = $url->dbi_dsn;
+  @userinfo = ($url->user, $url->password);
 
   $opt{AutoCommit}          //= 1;
   $opt{AutoInactiveDestroy} //= 1;
@@ -370,7 +375,12 @@ sub _dsn_for_mysql {
 
 sub _dsn_for_sqlite {
   my ($class, $url, $database_name) = @_;
-  my %opt = %{$url->query->to_hash};
+  my %opt = %{$url->query_form_hash};
+
+  $url = URI::db->new($url);
+  $url->dbname($database_name);
+  $url->query_param_delete($_) for $url->query_param;
+  my $dsn = $url->dbi_dsn;
 
   $opt{AutoCommit}          //= 1;
   $opt{AutoInactiveDestroy} //= 1;
@@ -378,7 +388,7 @@ sub _dsn_for_sqlite {
   $opt{RaiseError}          //= 1;
   $opt{sqlite_unicode}      //= 1;
 
-  return "dbi:SQLite:dbname=$database_name", "", "", \%opt;
+  return $dsn, "", "", \%opt;
 }
 
 sub _generate_database_name {
@@ -408,7 +418,7 @@ sub _generate_database_name {
   $name =~ s!^/+!!;
   $name =~ s!\W!_!g;
 
-  return $name if $self->url->scheme ne 'sqlite';
+  return $name if $self->url->canonical_engine ne 'sqlite';
   return File::Spec->catfile($self->_tempdir, "$name.sqlite");
 }
 

--- a/lib/DBIx/TempDB.pm
+++ b/lib/DBIx/TempDB.pm
@@ -74,9 +74,10 @@ use Cwd ();
 use DBI;
 use File::Basename ();
 use File::Spec;
+use IO::Handle ();
+use Sys::Hostname ();
 use URI::db;
 use URI::QueryParam;
-use Sys::Hostname ();
 
 use constant CWD => eval { File::Basename::dirname(Cwd::abs_path($0)) };
 use constant DEBUG               => $ENV{DBIX_TEMP_DB_DEBUG}               || 0;

--- a/t/drop-from-child-1.t
+++ b/t/drop-from-child-1.t
@@ -10,7 +10,7 @@ my @dsn;
   my $tmpdb         = DBIx::TempDB->new($ENV{TEST_PG_DSN}, drop_from_child => 1);
   my @dsn           = $tmpdb->dsn;
   my $dbh           = DBI->connect(@dsn);
-  my $database_name = $tmpdb->url->path->parts->[0];
+  my $database_name = $tmpdb->url->dbname;
   is $dbh->{pg_db}, $database_name, "pg_db $database_name";
 }
 

--- a/t/keep-database.t
+++ b/t/keep-database.t
@@ -1,6 +1,7 @@
 use strict;
 use Test::More;
 use DBIx::TempDB;
+use URI::db;
 
 plan skip_all => 'TEST_PG_DSN=postgresql://localhost' unless $ENV{TEST_PG_DSN};
 
@@ -9,12 +10,12 @@ $ENV{DBIX_TEMP_DB_SILENT} //= 1;
 my $tempdb = DBIx::TempDB->new($ENV{TEST_PG_DSN});
 undef $tempdb;    # should normally drop database
 
-my $url = Mojo::URL->new($ENV{DBIX_TEMP_DB_URL});
+my $url = URI::db->new($ENV{DBIX_TEMP_DB_URL});
 my $dbh = eval { DBI->connect(DBIx::TempDB->dsn($ENV{DBIX_TEMP_DB_URL})) };
 ok !$@, 'DBIX_TEMP_DB_KEEP_DATABASE=1' or diag $@;
 
 # clean up manually
 $dbh = DBI->connect(DBIx::TempDB->dsn("$ENV{TEST_PG_DSN}/postgres"));
-$dbh->do("drop database " . $url->path->parts->[0]);
+$dbh->do("drop database " . $url->dbname);
 
 done_testing;

--- a/t/mysql-offline.t
+++ b/t/mysql-offline.t
@@ -9,7 +9,7 @@ is $tmpdb->url, 'mysql://example.com', 'url';
 is_deeply(
   [$tmpdb->dsn],
   [
-    'dbi:mysql:dbname=foo;host=example.com',
+    'dbi:mysql:host=example.com;database=foo',
     undef, undef, {AutoCommit => 1, AutoInactiveDestroy => 1, PrintError => 0, RaiseError => 1, mysql_enable_utf8 => 1}
   ],
   'dsn for foo'
@@ -19,7 +19,7 @@ $tmpdb = DBIx::TempDB->new('mysql://u:p@127.0.0.1:1234?AutoCommit=0', auto_creat
 is_deeply(
   [$tmpdb->dsn],
   [
-    'dbi:mysql:dbname=yikes;host=127.0.0.1;port=1234',
+    'dbi:mysql:host=127.0.0.1;port=1234;database=yikes',
     'u', 'p', {AutoCommit => 0, AutoInactiveDestroy => 1, PrintError => 0, RaiseError => 1, mysql_enable_utf8 => 1}
   ],
   'dsn for tikes'
@@ -28,7 +28,7 @@ is_deeply(
 is_deeply(
   [DBIx::TempDB->dsn('mysql://x:y@example.com:2345/aiaiai')],
   [
-    'dbi:mysql:dbname=aiaiai;host=example.com;port=2345',
+    'dbi:mysql:host=example.com;port=2345;database=aiaiai',
     'x', 'y', {AutoCommit => 1, AutoInactiveDestroy => 1, PrintError => 0, RaiseError => 1, mysql_enable_utf8 => 1}
   ],
   'dsn for class'

--- a/t/mysql-online.t
+++ b/t/mysql-online.t
@@ -5,7 +5,7 @@ use DBIx::TempDB;
 plan skip_all => 'TEST_MYSQL_DSN=mysql://localhost' unless $ENV{TEST_MYSQL_DSN};
 
 my $tmpdb         = DBIx::TempDB->new($ENV{TEST_MYSQL_DSN});
-my $database_name = $tmpdb->url->path->parts->[0];
+my $database_name = $tmpdb->url->dbname;
 my $dbh           = DBI->connect($tmpdb->dsn);
 
 my $sth = $dbh->prepare('select database()');

--- a/t/pg-offline.t
+++ b/t/pg-offline.t
@@ -10,7 +10,7 @@ is $tmpdb->url, 'postgresql://example.com', 'url';
 is_deeply(
   [$tmpdb->dsn],
   [
-    'dbi:Pg:dbname=foo;host=example.com',
+    'dbi:Pg:host=example.com;dbname=foo',
     undef, undef, {AutoCommit => 1, AutoInactiveDestroy => 1, PrintError => 0, RaiseError => 1}
   ],
   'dsn for foo'
@@ -20,7 +20,7 @@ $tmpdb = DBIx::TempDB->new('postgresql://u:p@127.0.0.1:1234?AutoCommit=0', auto_
 is_deeply(
   [$tmpdb->dsn],
   [
-    'dbi:Pg:dbname=yikes;host=127.0.0.1;port=1234',
+    'dbi:Pg:host=127.0.0.1;port=1234;dbname=yikes',
     'u', 'p', {AutoCommit => 0, AutoInactiveDestroy => 1, PrintError => 0, RaiseError => 1}
   ],
   'dsn for tikes'

--- a/t/pg-online.t
+++ b/t/pg-online.t
@@ -8,7 +8,7 @@ my $tmpdb = DBIx::TempDB->new($ENV{TEST_PG_DSN}, auto_create => 0);
 is $ENV{DBIX_TEMP_DB_URL}, undef, 'DBIX_TEMP_DB_URL is not set';
 
 $tmpdb->create_database;
-my $database_name = $tmpdb->url->path->parts->[0];
+my $database_name = $tmpdb->url->dbname;
 is $ENV{DBIX_TEMP_DB_URL}, "$ENV{TEST_PG_DSN}/$database_name", 'DBIX_TEMP_DB_URL is set';
 
 my $dbh = DBI->connect($tmpdb->dsn);

--- a/t/sqlite-online.t
+++ b/t/sqlite-online.t
@@ -8,7 +8,7 @@ my $path = File::Spec->catfile(File::Spec->tmpdir, 'foo.sqlite');
 ok !-e $path, 'sqlite does not exist';
 
 my $tmpdb = DBIx::TempDB->new('sqlite://', template => 'foo');
-is $tmpdb->url, "sqlite://$path", 'url';
+is $tmpdb->url->dbname, $path, 'dbname';
 
 is_deeply(
   [$tmpdb->dsn],


### PR DESCRIPTION
URI::db provides a lot of functionality that is useful for database connections. Along with parsing the URI itself, I used its special methods to simplify determining the database engine to use, parsing out the database name, and generating the connection DSN.