### PR TITLE
creating a base sqlite URL with sqlite: instead of sqlite://

### DIFF
--- a/lib/DBIx/TempDB.pm
+++ b/lib/DBIx/TempDB.pm
@@ -211,7 +211,7 @@ sub execute_file {
   $self = DBIx::TempDB->new($url, %args);
   $self = DBIx::TempDB->new("mysql://127.0.0.1");
   $self = DBIx::TempDB->new("postgresql://postgres@db.example.com");
-  $self = DBIx::TempDB->new("sqlite://");
+  $self = DBIx::TempDB->new("sqlite:");
 
 Creates a new object after checking the C<$url> is valid. C<%args> can be:
 

--- a/t/sqlite-online.t
+++ b/t/sqlite-online.t
@@ -7,7 +7,7 @@ plan skip_all => 'Need nix OS' if $^O =~ /win32/i;
 my $path = File::Spec->catfile(File::Spec->tmpdir, 'foo.sqlite');
 ok !-e $path, 'sqlite does not exist';
 
-my $tmpdb = DBIx::TempDB->new('sqlite://', template => 'foo');
+my $tmpdb = DBIx::TempDB->new('sqlite:', template => 'foo');
 is $tmpdb->url->dbname, $path, 'dbname';
 
 is_deeply(


### PR DESCRIPTION
The URL "sqlite://" causes URI::db to turn a relative "dbname" into an absolute path, this may be a bug in URI::db but it is avoided by starting with the URL "sqlite:". "sqlite:foo.db" is unambiguous but "sqlite:///foo.db" is parsed as an absolute path, while "sqlite://localhost/foo.db" is parsed as a relative path. Passing an absolute "dbname" results in the same URL whether you start with "sqlite:" or "sqlite://".