### PR TITLE
allow execute of multiple statements by SQLite driver

### DIFF
--- a/lib/DBIx/TempDB.pm
+++ b/lib/DBIx/TempDB.pm
@@ -173,8 +173,8 @@ SQL server.
 sub execute {
   my ($self, $sql) = @_;
   my $dbh = DBI->connect($self->dsn);
-  my $sth = $dbh->prepare($sql);
-  $sth->execute;
+  local $dbh->{sqlite_allow_multiple_statements} = 1 if $self->url->canonical_engine eq 'sqlite';
+  $dbh->do($sql);
   $self;
 }
 


### PR DESCRIPTION
The SQLite driver has some issues with multiple statements in one query, but setting "sqlite_allow_multiple_statements" temporarily and using "do" without any bound parameters means that it will use DBI's "do" method directly, so that multiple statements will work fine. I don't think "prepare/execute" is needed here instead of "do" for postgres or mysql.