### PR TITLE
use query method directly to clear the URL query

### DIFF
--- a/lib/DBIx/TempDB.pm
+++ b/lib/DBIx/TempDB.pm
@@ -388,7 +388,7 @@ sub _dsn_for_pg {
 
   $url = URI::db->new($url);
   $url->dbname($database_name);
-  $url->query_param_delete($_) for $url->query_param;
+  $url->query(undef);
   if (my $service = delete $opt{service}) { $url->query_param(service => $service) }
   $dsn = $url->dbi_dsn;
   @userinfo = ($url->user, $url->password);
@@ -408,7 +408,7 @@ sub _dsn_for_mysql {
 
   $url = URI::db->new($url);
   $url->dbname($database_name);
-  $url->query_param_delete($_) for $url->query_param;
+  $url->query(undef);
   $dsn = $url->dbi_dsn;
   @userinfo = ($url->user, $url->password);
 
@@ -427,7 +427,7 @@ sub _dsn_for_sqlite {
 
   $url = URI::db->new($url);
   $url->dbname($database_name);
-  $url->query_param_delete($_) for $url->query_param;
+  $url->query(undef);
   my $dsn = $url->dbi_dsn;
 
   $opt{AutoCommit}          //= 1;


### PR DESCRIPTION
query_param_delete just calls query_form under the hood which eventually sets the query to undef, it's better to just do it directly since we're clearing all parameters. URI::QueryParam is still needed for ->query_form_hash.