### PR TITLE
Case-sensitivity fix

### DIFF
--- a/lib/DBIx/TempDB.pm
+++ b/lib/DBIx/TempDB.pm
@@ -246,6 +246,7 @@ sub _generate_database_name {
 
   $name =~ s!^/+!!;
   $name =~ s!\W!_!g;
+  $name = lc $name;
 
   return $name if $self->url->canonical_engine ne 'sqlite';
   return File::Spec->catfile($self->_tempdir, "$name.sqlite");

--- a/lib/DBIx/TempDB.pm
+++ b/lib/DBIx/TempDB.pm
@@ -238,7 +238,7 @@ sub _generate_database_name {
          $self->{template} =~ s!\%T!!g
       or $self->{template} =~ s!\%H!!g
       or $self->{template} =~ s!\%X!!g
-      or confess "Uable to create shorter database anme.";
+      or confess "Uable to create shorter database name.";
     warn "!!! Database name '$name' is too long! Forcing a shorter template: $self->{template}"
       if !$ENV{HARNESS_ACTIVE} or $ENV{HARNESS_VERBOSE};
     return $self->_generate_database_name($n);

--- a/t/database-name.t
+++ b/t/database-name.t
@@ -3,8 +3,8 @@ use Test::More;
 use DBIx::TempDB;
 
 my $tmpdb    = DBIx::TempDB->new('postgresql://example.com', auto_create => 0, keep_too_long_database_name => 1);
-my $exe      = File::Basename::basename($0);
-my $hostname = Sys::Hostname::hostname();
+my $exe      = lc File::Basename::basename($0);
+my $hostname = lc Sys::Hostname::hostname();
 my $uid      = $<;
 
 $exe =~ s!\W!_!g;
@@ -22,5 +22,9 @@ is $name, join('_', 'bar', $hostname, $$, $^T, $<, $exe, 'foo'), $name;
 
 $name = $tmpdb->_generate_database_name(3);
 is $name, join('_', 'bar', 3, $hostname, $$, $^T, $<, $exe, 'foo'), $name;
+
+$tmpdb->{template} = 'TEST';
+$name = $tmpdb->_generate_database_name(0);
+is $name, 'test';
 
 done_testing;


### PR DESCRIPTION
I have a small request:

In postgres, [unquoted identifiers are not case-sensitve](https://www.postgresql.org/docs/current/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS), however the connection URLs are case sensitive, which means if the template, hostname, or basenames contain upper-case characters, the resulting URL/DSN will not match the database created.  Two workarounds for this problem are:

  1. Use a template that is all lower-case (e.g. `'test%i'`)
  2. Change the create / drop commands to `'create database "%d"'` and `'drop database "%d"'` respectively.

Either workaround is a relatively simple addition to the `->new(...)` call, but it would be nice to have the default constructor be reliable.  Of these approaches, option 2 might well be the best, but the documentation says that the default template may change while no such caveat is given for the `create_database_command` and `drop_database_command` defaults.  Therefore, I propose having `_generate_database_name` always return lower-case strings.

PS: Thanks for the Module!